### PR TITLE
Slight refactor to allow 'package' section/step to be truly optional

### DIFF
--- a/berth/cli.py
+++ b/berth/cli.py
@@ -48,12 +48,14 @@ def main(context, config_file, verbose, debug, build_only, package_only, keep_co
         if not build.build(configuration):
             context.exit(1)
 
-    if not utils.pull_image(configuration['package'].get('image', 'tenzer/fpm')):
-        context.exit(1)
-
     if build_only:
         utils.info('--build-only provided, skipping packaging.')
+    elif 'package' not in configuration:
+        utils.info('No package configuration provided, skipping package.')
     else:
+        if not utils.pull_image(configuration['package'].get('image', 'tenzer/fpm')):
+            context.exit(1)
+
         if not package.package(configuration):
             context.exit(1)
 

--- a/berth/config.py
+++ b/berth/config.py
@@ -36,8 +36,11 @@ def verify(config):
     else:
         utils.debug('No "build" section found in configuration.')
 
-    for error in verify_package(config):
-        errors.append(error)
+    if 'package' in config:
+        for error in verify_package(config):
+            errors.append(error)
+    else:
+        utils.debug('No "package" section found in configuration.')
 
     for section in {'build', 'package'}:
         for local_path, container_path in config.get(section, dict()).get('volumes', dict()).items():


### PR DESCRIPTION
This actually facilitates #7 by just using the build section to do the heavy lifting and just skip the fpm callout.  A much lighter change than we had discussed originally and gets the job done for basically any packaging system.
